### PR TITLE
Return error tuple when Abacus.eval() runs into an unexcepted error

### DIFF
--- a/lib/abacus.ex
+++ b/lib/abacus.ex
@@ -77,8 +77,9 @@ defmodule Abacus do
   end
 
   def eval(expr, scope) when is_binary(expr) or is_bitstring(expr) do
-    with {:ok, parsed} = parse(expr) do
-      eval(parsed, scope)
+    case parse(expr) do
+      {:ok, parsed} -> eval(parsed, scope)
+      {:error, error} -> {:error, error}
     end
   end
 

--- a/test/math_eval_test.exs
+++ b/test/math_eval_test.exs
@@ -84,5 +84,9 @@ defmodule MathEvalTest do
     test "invalid boolean arithmetic" do
       assert {:error, _} = Abacus.eval("false + 1")
     end
+
+    test "unexpected token" do
+      assert {:error, _} = Abacus.eval("1 + )")
+    end
   end
 end


### PR DESCRIPTION
Added {:error, _} return on Abacus.eval() when there is the expression is invalid or contains an unexpected token
Added unit test to test that Abacus.eval("1 + )") returns an error tuple.