### PR TITLE
Add docs for the variables/1 function

### DIFF
--- a/lib/abacus.ex
+++ b/lib/abacus.ex
@@ -129,6 +129,9 @@ defmodule Abacus do
     end
   end
 
+  @doc """
+  Takes a Abacus tree, that is a mathematic expression that has already been parsed and extract its variables"""
+  
   def variables(expr) do
     Abacus.Tree.reduce(expr, fn
       {:access, variables} ->


### PR DESCRIPTION
The variables function was missing documentation and I was struggling giving it a string instead of Abacus tree. My commit adds a clarification about it.