### PR TITLE
update the version in the instructions README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ An incomplete list of supported and planned features
 
   ```elixir
   def deps do
-    [{:abacus, "~> 0.4.2"}]
+    [{:abacus, "~> 2.0.0"}]
   end
   ```
 


### PR DESCRIPTION
Hi! I just noticed that the latest version of Abacus on Hex has been 2.0.0 for a year - https://hex.pm/packages/abacus

Maybe it's time to update the installation instructions? 🤔 