### PR TITLE
Add 'in' operator for list membership

### DIFF
--- a/lib/compile.ex
+++ b/lib/compile.ex
@@ -11,11 +11,12 @@ defmodule Abacus.Compile do
   @bitwise_ops ~w[&&& ||| ^^^ ~~~ <<< >>>]a
 
   def add_use_bitwise(ast) do
-    {_, contains_bitwise} = Macro.prewalk(ast, false, fn
-      {op, _, _}, false = ast when op in @bitwise_ops -> {ast, true}
-      ast, true -> {ast, true}
-      ast, false -> {ast, false}
-    end)
+    {_, contains_bitwise} =
+      Macro.prewalk(ast, false, fn
+        {op, _, _}, false = ast when op in @bitwise_ops -> {ast, true}
+        ast, true -> {ast, true}
+        ast, false -> {ast, false}
+      end)
 
     case contains_bitwise do
       true ->
@@ -23,6 +24,7 @@ defmodule Abacus.Compile do
           use Bitwise
           unquote(ast)
         end
+
       false ->
         ast
     end
@@ -31,12 +33,15 @@ defmodule Abacus.Compile do
   def prepare_variables({:., ctx, [lhs, {:variable, name}]}) do
     put_get_in(ctx, [prepare_variables(lhs), name])
   end
+
   def prepare_variables({:., _, [_, :get_in]} = ast) do
     ast
   end
+
   def prepare_variables({:., ctx, [lhs, expr]}) do
     put_get_in(ctx, [lhs, expr])
   end
+
   def prepare_variables(diff) do
     diff
   end
@@ -47,13 +52,11 @@ defmodule Abacus.Compile do
       |> Module.split()
       |> Enum.map(&String.to_atom/1)
 
-    {{:., [],
-      [{:__aliases__, [alias: false], module}, function]}, [], args}
+    {{:., [], [{:__aliases__, [alias: false], module}, function]}, [], args}
   end
 
   def put_get_in(ctx, args) do
-    {{:., [],
-      [{:__aliases__, [alias: false], [:Abacus, :Runtime, :Scope]}, :get_in]}, ctx, args}
+    {{:., [], [{:__aliases__, [alias: false], [:Abacus, :Runtime, :Scope]}, :get_in]}, ctx, args}
   end
 
   def replace_operators({:^, _ctx, [lhs, rhs]}) do
@@ -61,32 +64,37 @@ defmodule Abacus.Compile do
       :math.pow(unquote(lhs), unquote(rhs))
     end
   end
+
   def replace_operators({:!, _ctx, [expr]}) do
     quote do
       Abacus.Runtime.Helpers.factorial(unquote(expr))
     end
   end
+
   def replace_operators(diff) do
     diff
   end
 
-  def prepare_fn_calls({{var, _, nil} = variable, ctx, args} = ast) when is_list(args) and is_atom(var) do
+  def prepare_fn_calls({{var, _, nil} = variable, ctx, args} = ast)
+      when is_list(args) and is_atom(var) do
     if var |> to_string |> String.starts_with?("var") do
       {{:., ctx, [variable]}, ctx, args}
     else
       ast
     end
   end
+
   def prepare_fn_calls(diff) do
     diff
   end
 
-  @compare_ops ~w[== != >= <= > <]a
+  @compare_ops ~w[== != >= <= > < in]a
 
   def inject_comparison({op, _ctx, args}) when op in @compare_ops do
     args = Enum.map(args, &mfa(Abacus.Runtime.Helpers, :cast_for_comparison, [&1]))
     mfa(Abacus.Runtime.Helpers, :compare, [op | args])
   end
+
   def inject_comparison(ast) do
     ast
   end

--- a/lib/runtime/helpers.ex
+++ b/lib/runtime/helpers.ex
@@ -2,6 +2,7 @@ defmodule Abacus.Runtime.Helpers do
   def cast_for_comparison(atom) when is_atom(atom) do
     to_string(atom)
   end
+
   def cast_for_comparison(other) do
     other
   end
@@ -16,11 +17,17 @@ defmodule Abacus.Runtime.Helpers do
   def compare(op, lhs, rhs, type, type) do
     apply(Kernel, op, [lhs, rhs])
   end
+
   def compare(op, lhs, rhs, lt, rt) when lt in ~w[float integer]a and rt in ~w[float integer]a do
     apply(Kernel, op, [lhs, rhs])
   end
+
   def compare(op, _, _, lt, rt) when lt != rt and op in ~w[== > < >= <=]a, do: false
   def compare(:!=, _, _, lt, rt) when lt != rt, do: true
+
+  def compare(:in, lhs, rhs, lt, rt) when rt == :list do
+    Enum.member?(rhs, lhs)
+  end
 
   @type typeof :: :atom | :binary | :float | :integer | :list | :map
   @spec typeof(any) :: typeof
@@ -58,12 +65,13 @@ defmodule Abacus.Runtime.Helpers do
   """
   @spec factorial(number) :: number
   def factorial(0), do: 1
+
   def factorial(n) when n > 0 do
     _factorial(1, n, 1)
   end
 
   def _factorial(n, m, r) when n < m do
-     _factorial(n + 1, m, r * (n + 1))
+    _factorial(n + 1, m, r * (n + 1))
   end
 
   def _factorial(n, n, r), do: r

--- a/src/math_term.xrl
+++ b/src/math_term.xrl
@@ -32,6 +32,7 @@ STRING = "([^\\"]+|\\"|\\)*"
 
 Rules.
 % reserved words appear up here so they're not eaten by {WORD}
+in : {token, {'in', TokenLine}}.
 not : {token, {'not', TokenLine}}.
 null : {token, {nil, TokenLine}}.
 false : {token, {false, TokenLine}}.

--- a/src/math_term_parser.yrl
+++ b/src/math_term_parser.yrl
@@ -5,7 +5,7 @@ Terminals '(' ')'
   '.' '[' ']'
   '~' '&' '|' '|^' '<<' '>>'
   'and' 'or' 'not' '?' ':'
-  '==' '!=' '<=' '>=' '<' '>' nil true false string.
+  '==' '!=' '<=' '>=' '<' '>' 'in' nil true false string.
 Nonterminals expr argument arguments function variable variables signed_number.
 Rootsymbol expr.
 Unary 1000 '!'.
@@ -15,14 +15,13 @@ Unary 800 '~'.
 Left 750 '*' '/'.
 Left 700 '+' '-'.
 Left 600 '<<' '>>'.
-Left 590 '==' '!=' '<=' '<' '>=' '>'.
+Left 590 '==' '!=' '<=' '<' '>=' '>' 'in'.
 Left 580 '&'.
 Left 550 '|^'.
 Left 520 '|'.
 Left 480 'and'.
 Left 420 'or'.
 Right 300 '?' ':'.
-
 
 Unary 100 function.
 Unary 0 variable.
@@ -38,6 +37,7 @@ expr -> expr '>=' expr : {gte, '$1', '$3'}.
 expr -> expr '<=' expr : {lte, '$1', '$3'}.
 expr -> expr '<' expr : {lt, '$1', '$3'}.
 expr -> expr '>' expr : {gt, '$1', '$3'}.
+expr -> expr 'in' variables : {in, concat([extract('$1'), [{index, '$3'}]])}.
 
 expr -> expr 'and' expr : {logical_and, '$1', '$3'}.
 expr -> expr 'or' expr : {logical_or, '$1', '$3'}.

--- a/src/new_parser.yrl
+++ b/src/new_parser.yrl
@@ -5,7 +5,7 @@ Terminals '(' ')' '{' '}' newline
   '.' '[' ']'
   '~' '&' '|' '|^' '<<' '>>'
   'and' 'or' 'not' '?' ':'
-  '==' '!=' '<=' '>=' '<' '>' nil true false string.
+  '==' '!=' '<=' '>=' '<' '>' 'in' nil true false string.
 Nonterminals expr statement statements argument arguments function variable variables signed_number lambda block.
 Rootsymbol expr.
 Left 1200 '(' ')'.
@@ -17,14 +17,13 @@ Unary 800 '~'.
 Left 750 '*' '/'.
 Left 700 '+' '-'.
 Left 600 '<<' '>>'.
-Left 590 '==' '!=' '<=' '<' '>=' '>'.
+Left 590 '==' '!=' '<=' '<' '>=' '>' 'in'.
 Left 580 '&'.
 Left 550 '|^'.
 Left 520 '|'.
 Left 480 'and'.
 Left 420 'or'.
 Right 300 '?' ':'.
-
 
 Unary 100 function.
 Unary 20 argument.
@@ -41,6 +40,7 @@ expr -> expr '>=' expr : {'>=', [], ['$1', '$3']}.
 expr -> expr '<=' expr : {'<=', [], ['$1', '$3']}.
 expr -> expr '<' expr : {'<', [], ['$1', '$3']}.
 expr -> expr '>' expr : {'>', [], ['$1', '$3']}.
+expr -> expr 'in' variables : {'in', [], ['$1', '$3']}.
 
 expr -> expr 'and' expr : {'&&', [], ['$1', '$3']}.
 expr -> expr 'or' expr : {'||', [], ['$1', '$3']}.
@@ -109,16 +109,18 @@ Erlang code.
 
 extract_token({_Token, _Line, Value}) -> Value.
 
-var({variable, Name}) -> 
-  Variables = 'Elixir.Process':get(variables, maps:new()),
-  Symbol = case maps:get(Name, Variables, nil) of
-    nil -> 
-      Len = maps:size(Variables),
-      LenS = integer_to_binary(Len),
-      SymbolGen = binary_to_atom(<<"var", LenS/binary>>, utf8),
-      UpdatedVariables = maps:put(Name, SymbolGen, Variables),
-      'Elixir.Process':put(variables, UpdatedVariables),
-      SymbolGen;
-    S -> S
-  end,
-  {Symbol, [], 'nil'}.
+var({variable, Name}) ->
+    Variables = 'Elixir.Process':get(variables, maps:new()),
+    Symbol =
+        case maps:get(Name, Variables, nil) of
+            nil ->
+                Len = maps:size(Variables),
+                LenS = integer_to_binary(Len),
+                SymbolGen = binary_to_atom(<<"var", LenS/binary>>, utf8),
+                UpdatedVariables = maps:put(Name, SymbolGen, Variables),
+                'Elixir.Process':put(variables, UpdatedVariables),
+                SymbolGen;
+            S ->
+                S
+        end,
+    {Symbol, [], 'nil'}.

--- a/test/math_eval_test.exs
+++ b/test/math_eval_test.exs
@@ -25,28 +25,30 @@ defmodule MathEvalTest do
     end
 
     test "factorial" do
-      assert {:ok, 3628800} == Abacus.eval("(5 * 2)!")
+      assert {:ok, 3_628_800} == Abacus.eval("(5 * 2)!")
     end
 
     test "variables" do
-      assert {:ok, 10} == Abacus.eval("a.b.c[1]", %{
-        "a" => %{
-          "b" => %{
-            "c" => [
-              1,
-              10,
-              -42
-            ]
-          }
-        }
-        })
+      assert {:ok, 10} ==
+               Abacus.eval("a.b.c[1]", %{
+                 "a" => %{
+                   "b" => %{
+                     "c" => [
+                       1,
+                       10,
+                       -42
+                     ]
+                   }
+                 }
+               })
     end
 
     test "variable in index expression" do
-      assert {:ok, 10} == Abacus.eval("list[a]", %{
-        "list" => [1, 2, 3, 10, 5],
-        "a" => 3
-        })
+      assert {:ok, 10} ==
+               Abacus.eval("list[a]", %{
+                 "list" => [1, 2, 3, 10, 5],
+                 "a" => 3
+               })
     end
 
     test "bitwise operators" do
@@ -100,6 +102,14 @@ defmodule MathEvalTest do
       assert {:ok, true} = Abacus.eval("null != 30")
       assert {:ok, true} = Abacus.eval("a == b", %{a: 30, b: 30.0})
       assert {:ok, true} = Abacus.eval("a == b", %{a: "abc", b: :abc})
+      assert {:ok, false} = Abacus.eval("5 in b", %{a: 30, b: [1, 2, 30]})
+      assert {:ok, true} = Abacus.eval("2 in b", %{a: 30, b: [1, 2, 30]})
+      assert {:ok, true} = Abacus.eval("a in b", %{a: 30, b: [1, 2, 30]})
+      assert {:ok, true} = Abacus.eval("a in b.c", %{a: 30, b: %{c: [1, 2, 30]}})
+      assert {:ok, true} = Abacus.eval("\"a\" in x", %{x: ["a", "b", "c"]})
+      assert {:ok, false} = Abacus.eval("\"d\" in x", %{x: ["a", "b", "c"]})
+      assert {:ok, true} = Abacus.eval("y in x", %{x: ["a", "b", "c"], y: "b"})
+      assert {:ok, false} = Abacus.eval("y in x", %{x: ["a", "b", "c"], y: "d"})
     end
 
     test "default scope injection" do


### PR DESCRIPTION
This PR adds the `in` keyword to enable checking list membership.

Examples:

`Abacus.eval("\"apple\" in fruits", %{"fruits" => ["apple", "banana", "orange"]})`

`Abacus.eval("a in b", %{"a" => 1, "b" => [1,2,3]})`

RHS always expects a list (can be nested access), LHS can be any expression.