### PR TITLE
fix: parse warning

### DIFF
--- a/lib/abacus.ex
+++ b/lib/abacus.ex
@@ -100,6 +100,11 @@ defmodule Abacus do
     end
   end
 
+  @doc false
+  def parse(source) do
+    with {:ok, ast, _vars} <- compile(source), do: {:ok, ast}
+  end
+
   def compile(source) when is_binary(source) do
     source
     |> String.to_charlist()


### PR DESCRIPTION
Fixes the following warning with:

- Erlang/OTP: 28 (erts-16.2)
- Elixir: 1.19.5
- Abacus: 2.1.0

```
warning: Abacus.parse/1 is undefined or private
      │
   36 │       Abacus.parse(without_parantheses),
      │              ~
      │
      └─ lib/format.ex:36:14: Abacus.Format.format/1
      └─ lib/format.ex:37:14: Abacus.Format.format/1
      └─ lib/format.ex:38:14: Abacus.Format.format/1
      └─ lib/format.ex:39:14: Abacus.Format.format/1
      └─ lib/format.ex:64:14: Abacus.Format.format/1
      └─ lib/format.ex:65:14: Abacus.Format.format/1
      └─ lib/format.ex:81:14: Abacus.Format.format/1
      └─ lib/format.ex:82:14: Abacus.Format.format/1
      └─ lib/format.ex:100:28: Abacus.Format.format/1

  Generated abacus app
```