### PR TITLE
Parse trailing-dot floats like 1. instead of raising

### DIFF
--- a/src/math_term.xrl
+++ b/src/math_term.xrl
@@ -38,7 +38,7 @@ false : {token, {false, TokenLine}}.
 true : {token, {true, TokenLine}}.
 
 {INTEGER}    : {token, {number, TokenLine, list_to_integer(TokenChars)}}.
-{FLOAT_END}      : {token, {number, TokenLine, list_to_float(TokenChars)}}.
+{FLOAT_END}      : {token, {number, TokenLine, list_to_float(pad_float_end(TokenChars))}}.
 {FLOAT_START}      : {token, {number, TokenLine, list_to_float([48 | TokenChars])}}.
 {P_OPEN}    : {token, {'(', TokenLine}}.
 {P_CLOSE}   : {token, {')', TokenLine}}.
@@ -79,5 +79,13 @@ true : {token, {true, TokenLine}}.
 {COMMA} : {token, {',', TokenLine}}.
 
 Erlang code.
-parse_string(Chars) -> 
+parse_string(Chars) ->
   'Elixir.Abacus.Runtime.Helpers':unescape_string(Chars).
+
+% A FLOAT_END token like "1." has no digits after the dot, which
+% list_to_float/1 rejects. Append a trailing zero so it parses as "1.0".
+pad_float_end(Chars) ->
+  case lists:last(Chars) of
+    $. -> Chars ++ "0";
+    _ -> Chars
+  end.

--- a/test/math_eval_test.exs
+++ b/test/math_eval_test.exs
@@ -117,6 +117,11 @@ defmodule MathEvalTest do
       assert {:error, _} = Abacus.eval("1 + )")
     end
 
+    test "trailing dot float" do
+      assert {:ok, 1.0} == Abacus.eval("1.")
+      assert {:ok, 42.0} == Abacus.eval("42.")
+    end
+
     test "array literals" do
       assert {:ok, [1, 2, "string"]} = Abacus.eval(~s{[1, 2, "string"]})
       assert {:ok, []} = Abacus.eval("[]")


### PR DESCRIPTION
Closes #30.

The `FLOAT_END` lexer rule allows zero digits after the dot, so `1.` tokenizes to `'1.'` and then `list_to_float('1.')` raises an ArgumentError out of the lexer rather than returning `{:error, ...}`. This mirrors how `FLOAT_START` already prepends a zero for inputs like `.5`; here I append a trailing zero so `1.` parses as `1.0`.